### PR TITLE
Fixed error for updating hosted clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/couchbasecloud/terraform-provider-couchbasecapella
 go 1.15
 
 require (
-	github.com/couchbasecloud/couchbase-capella-api-go-client v0.0.0-20220114092813-8323dc35022e
+	github.com/couchbasecloud/couchbase-capella-api-go-client v0.0.0-20220222152544-72d8ea8d2fa7
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.8.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/couchbasecloud/couchbase-capella-api-go-client v0.0.0-20220114092813-8323dc35022e h1:toacprcWmEkYi9UaErHsKQ3eSFWX4WhFnmTVqXwOs5w=
 github.com/couchbasecloud/couchbase-capella-api-go-client v0.0.0-20220114092813-8323dc35022e/go.mod h1:03u0LWYFTdpJ0aptWx3hR03fNJM0frsSUQN0Ez3ZXMc=
+github.com/couchbasecloud/couchbase-capella-api-go-client v0.0.0-20220222152544-72d8ea8d2fa7 h1:WkzNRlyJYeJtDLR3yldvhQhO/LLXiMaztIbSRYsX+8o=
+github.com/couchbasecloud/couchbase-capella-api-go-client v0.0.0-20220222152544-72d8ea8d2fa7/go.mod h1:QPVzXaeaBgzUID2BBafzxFZGs1i0YdG8l0J8iseTZaY=
 github.com/couchbaselabs/couchbase-cloud-go-client v1.0.2-0.20211201143422-2b4d1f40f66d h1:4RjL4hKYnqvQHVLmzN4NwRR+2y1rnmyCWx/RkNtdqjw=
 github.com/couchbaselabs/couchbase-cloud-go-client v1.0.2-0.20211201143422-2b4d1f40f66d/go.mod h1:7BNRWBnJJpY+jkPsHSkV4+OGSDOWN5lxnQdPOYitmN8=
 github.com/couchbaselabs/couchbase-cloud-go-client v1.4.0/go.mod h1:7BNRWBnJJpY+jkPsHSkV4+OGSDOWN5lxnQdPOYitmN8=

--- a/provider/resource_couchbasecapella_hosted_cluster.go
+++ b/provider/resource_couchbasecapella_hosted_cluster.go
@@ -324,7 +324,7 @@ func resourceCouchbaseCapellaHostedClusterUpdate(ctx context.Context, d *schema.
 
 		// Wait for the cluster to deploy
 		updateStateConf := &resource.StateChangeConf{
-			Pending: []string{"deploying"},
+			Pending: []string{"deploying", "scaling"},
 			Target:  []string{"healthy"},
 			Refresh: func() (interface{}, string, error) {
 				statusResp, _, err := client.ClustersV3Api.ClustersV3status(auth, clusterId).Execute()
@@ -377,8 +377,8 @@ func resourceCouchbaseCapellaHostedClusterDelete(ctx context.Context, d *schema.
 			return statusResp, string(statusResp.Status), nil
 		},
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Minute,
-		MinTimeout: 5 * time.Second,
+		Delay:      2 * time.Minute,
+		MinTimeout: 30 * time.Second,
 	}
 	_, err = deleteStateConf.WaitForStateContext(ctx)
 	if err != nil {


### PR DESCRIPTION
- Added new version of go client to go.mod
- Added new scaling status to pending statuses when updating hosted cluster

Fixes the [issue](https://github.com/couchbasecloud/terraform-provider-couchbasecapella/issues/11) where scaling was an invalid V3ClusterStatus.