### PR TITLE
Fixed error when modifying VPC Cluster configuration

### DIFF
--- a/provider/resource_couchbasecapella_vpc_cluster.go
+++ b/provider/resource_couchbasecapella_vpc_cluster.go
@@ -70,12 +70,14 @@ func resourceCouchbaseCapellaVpcCluster() *schema.Resource {
 							Type:         schema.TypeInt,
 							Description:  "Number of nodes",
 							Required:     true,
+							ForceNew:     true,
 							ValidateFunc: validateSize,
 						},
 						"services": {
 							Type:        schema.TypeList,
 							Description: "Couchbase Services",
 							Required:    true,
+							ForceNew:    true,
 							MinItems:    1,
 							Elem: &schema.Schema{
 								Type:         schema.TypeString,
@@ -86,18 +88,21 @@ func resourceCouchbaseCapellaVpcCluster() *schema.Resource {
 							Description: "Aws configuration",
 							Type:        schema.TypeSet,
 							Optional:    true,
+							ForceNew:    true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"instance_size": {
 										Description:  "Aws instance",
 										Type:         schema.TypeString,
 										Required:     true,
+										ForceNew:     true,
 										ValidateFunc: validateAwsInstance,
 									},
 									"ebs_size_gib": {
 										Description:  "Aws volume size (Gb)",
 										Type:         schema.TypeInt,
 										Required:     true,
+										ForceNew:     true,
 										ValidateFunc: validateAwsVolumeSize,
 									},
 								},
@@ -107,18 +112,21 @@ func resourceCouchbaseCapellaVpcCluster() *schema.Resource {
 							Description: "Azure configuration",
 							Type:        schema.TypeSet,
 							Optional:    true,
+							ForceNew:    true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"instance_size": {
 										Description:  "Azure instance",
 										Type:         schema.TypeString,
 										Required:     true,
+										ForceNew:     true,
 										ValidateFunc: validateAzureInstance,
 									},
 									"volume_type": {
 										Description:  "Azure volume size (Gb)",
 										Type:         schema.TypeString,
 										Required:     true,
+										ForceNew:     true,
 										ValidateFunc: validateAzureVolume,
 									},
 								},


### PR DESCRIPTION
When modifying the terraform configuration file for a VPC Cluster that has already been deployed, running `terraform apply` will result in the following error: 

```
Plan: 0 to add, 1 to change, 0 to destroy.
couchbasecapella_vpc_cluster.cluster: Modifying... [id=<cluster-id>]
╷
│ Error: doesn't support update
│ 
│   with couchbasecapella_vpc_cluster.cluster,
│   on main.tf line 11, in resource "couchbasecapella_vpc_cluster" "cluster":
│   11: resource "couchbasecapella_vpc_cluster" "cluster" {
│ 
╵
Releasing state lock. This may take a few moments...
ERRO[0046] 1 error occurred:
        * exit status 1
```

The expected behaviour should be to delete the currently deployed VPC Cluster and then recreate it with the updated configuration. 

I've added `ForceNew: true` to all fields of `resource_couchbasecapella_vpc_cluster.go`. `ForceNew: true` tells Terraform that any change to this field should result in the deletion and recreation of the resource.

This change fixes #17.