### PR TITLE
Allow API base URL to be overriden with env var

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -10,6 +10,7 @@ package provider
 
 import (
 	"context"
+	"os"
 
 	couchbasecapella "github.com/couchbasecloud/couchbase-capella-api-go-client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -55,6 +56,14 @@ func Provider() *schema.Provider {
 // providerConfigure is responsible for initializing the client
 func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	configuration := couchbasecapella.NewConfiguration()
+	if baseUrl := os.Getenv("CBC_API_URL"); baseUrl != "" {
+		configuration.Servers = couchbasecapella.ServerConfigurations{
+			{
+				URL:         baseUrl,
+				Description: "No description provided",
+			},
+		}
+	}
 	apiClient := couchbasecapella.NewAPIClient(configuration)
 	return apiClient, nil
 }


### PR DESCRIPTION
For internal use, it is useful to be able to specify the base URL to use when calling the Capella API so that the provider can be used in dev, stage or sandbox environments.

This change allows the base URL to be provided via the environment variable `CBC_API_URL`, and if it isn't provided, the default base URL `https://cloudapi.cloud.couchbase.com` is used.