### PR TITLE
Fix CI tag Filter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: ^v\d+\.\d+\.\d+$
+              only: /^v\d+\.\d+\.\d+$/
           context:
             - hashicorp-terraform
 jobs:


### PR DESCRIPTION
The CI Tag filter currently does run on a tag creation. This minor edit allows the workflow to run on a tag successfully

Testing:
![Image 2022-06-14 at 12 29 01 PM](https://user-images.githubusercontent.com/12391135/173567192-aa30478f-5b3d-4fd2-9813-bbadcfbd37b4.jpg)
