### PR TITLE
Fixed Cluster number of nodes validation

### DIFF
--- a/provider/errors.go
+++ b/provider/errors.go
@@ -32,7 +32,7 @@ const (
 	VpcClusterServerDoesNotMatchProvider string = "cluster's server should be the same as the cloud provider"
 
 	ClusterInvalidName             string = "cluster name can include letters, numbers, spaces, periods (.), dashes (-), and underscores (_). Cluster name should be between 2 and 128 characters and must begin with a letter or a number"
-	ClusterInvalidSize             string = "expected a value between 3 and 27, got %v"
+	ClusterInvalidSize             string = "expected a value between 2 and 27, got %v"
 	ClusterInvalidCouchbaseService string = "expected a valid value for service {data, index, query, search, eventing, analytics}, got %s"
 	ClusterInvalidStorageType      string = "expected a valid value for storage type {GP3, IO2}, got %s"
 	ClusterProblemAccessing        string = "a problem occurred while accessing the cluster"

--- a/provider/validate.go
+++ b/provider/validate.go
@@ -119,7 +119,7 @@ func validateSupportPackageType(val interface{}, key string) (warns []string, er
 
 func validateSize(val interface{}, key string) (warns []string, errs []error) {
 	size := val.(int)
-	sizeIsValid := size >= 3 && size < 28
+	sizeIsValid := size >= 2 && size < 28
 	if !sizeIsValid {
 		errs = append(errs, fmt.Errorf(ClusterInvalidSize, size))
 	}


### PR DESCRIPTION
The current validation prevented the user from being able to create 2 node clusters for services, e.g. Index, like you can in the Capella UI.

This change reduces the minimum number of nodes to 2 in validate.go. This will now allow you to have cluster size set to 2 in your terraform configuration file, whereas before this would throw an error. The error message has also been edited.

The value was originally set to 3 because the data service requires at least 3 nodes. Specifying size as 3 for the data service will now result in a 422 error on `terraform apply` as the API doesn't allow this value.

Ideally validation could be linked between the two fields, service and size. However, this is quite complicated to implement using the terraform SDK.

This PR fixes #16.